### PR TITLE
Time should not move 1 hour during daylight savings time

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -8,7 +8,7 @@ requires jQuery 1.6+
 
 (function($)
 {
-	var _tzOffset = new Date().getTimezoneOffset();
+	var _baseDate = new Date(); _baseDate.setHours(0); _baseDate.setMinutes(0);
 	var _ONE_DAY = 86400;
 	var _defaults =	{
 		className: null,
@@ -434,7 +434,7 @@ requires jQuery 1.6+
 
 	function _int2time(seconds, format)
 	{
-		var time = new Date((seconds + _tzOffset*60)*1000);
+		var time = new Date(_baseDate.valueOf() + (seconds*1000));
 		var output = '';
 
 		for (var i=0; i<format.length; i++) {


### PR DESCRIPTION
The problem stems from the call to new Date on line 437. We create a date at the beginning of time (which is in standard time) instead of the time zone we are currently in.

The attached patch changes this so that we create the date today at the given time. 

This doesn't fix all the problems (given that this library does not know whether or not we want to construct the date in DST or not) but it will no longer convert an input field with 10:00 PM in it to 9:00 PM.
