### PR TITLE
Updating the webpage to point to the correct datepair link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -284,7 +283,7 @@ $('#stepExample2').timepicker({ 'step': 60 });</pre>
 			<input type="text" class="date end" />
 		</p>
 
-		<p>Datepair source available <a href="http://jonthornton.github.com/jquery-timepicker/datepair.js">here</a>.</p>
+		<p>Datepair source available <a href="http://jonthornton.github.com/jquery-timepicker/lib/datepair.js">here</a>.</p>
 	</div>
 
 


### PR DESCRIPTION
The link for the datepair had the wrong reference. This simply corrects it to find it under the lib folder.
