### PR TITLE
Problem when changing the time textbox with javascript

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -91,6 +91,10 @@ requires jQuery 1.6+
 			var self = $(this);
 			var list = self.siblings('.ui-timepicker-list');
 
+			//Update List
+			list.find('li').removeClass('ui-timepicker-selected');
+			_selectValue(self);
+
 			// check if a flag was set to close this picker
 			if (self.hasClass('ui-timepicker-hideme')) {
 				self.removeClass('ui-timepicker-hideme');


### PR DESCRIPTION
When you change the time textbox with $('#setTimeExample').timepicker('setTime', new Date()); or directly with javascript the selected time is not going to change. I added two line on the show method to update the list with the current value of the textarea.
