### PR TITLE
Fixed regex to handle setTime with date objects whose minute value is <10

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -557,7 +557,7 @@ requires jQuery 1.6+
 		}
 
 		var d = new Date(0);
-		var time = timeString.toLowerCase().match(/(\d+)(?::(\d\d))?\s*([pa]?)/);
+		var time = timeString.toLowerCase().match(/(\d+)(?::(\d\d?))?\s*([pa]?)/);
 
 		if (!time) {
 			return null;


### PR DESCRIPTION
The "timeString = timeString.getHours()+':'+timeString.getMinutes();" will create a bogus date string when minutes<10 which the regex can't handle.
