### PR TITLE
Prevent error in hide when timepicker el no longer exists

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -168,7 +168,7 @@ requires jQuery 1.6+
 				var self = list.data('timepicker-input');
 				var settings = self.data('timepicker-settings');
 
-				if (settings.selectOnBlur) {
+				if (settings && settings.selectOnBlur) {
 					_selectValue(self);
 				}
 


### PR DESCRIPTION
this fixes a JS error for me in the case where a user hits the "cancel" button on a form (which removes the form from dom) while the timepicker dropdown is still open
