### PR TITLE
Intelligent calculation of z-index rather than setting to arbitrary high value

### DIFF
--- a/jquery.timepicker.css
+++ b/jquery.timepicker.css
@@ -11,7 +11,6 @@
 	-moz-box-shadow:0 5px 10px rgba(0,0,0,0.2);
 	box-shadow:0 5px 10px rgba(0,0,0,0.2);
 	outline: none;
-	z-index: 10001;
 }
 
 .ui-timepicker-list.ui-timepicker-with-duration {

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -252,7 +252,10 @@ requires jQuery 1.6+
 			list.addClass(settings.className);
 		}
 
-		list.css({'display':'none', 'position': 'absolute' });
+		var zIndex = parseInt(self.parents().filter(function() {
+			return $(this).css('z-index') != 'auto';
+		}).first().css('z-index'))+10;
+		list.css({'display':'none', 'position': 'absolute', 'zIndex': zIndex });
 
 		if (settings.minTime !== null && settings.showDuration) {
 			list.addClass('ui-timepicker-with-duration');


### PR DESCRIPTION
Z-index was being set to some arbitrarily high value in CSS. Thought it works in most cases, it would break when some container has even higher z-index (like in http://jsfiddle.net/Qkgxu/5/). Fixed it by setting it to a value 10 units more than the z-index of the closest ancestor with non-auto z-index.
