### PR TITLE
Show duration when a durationTime or minTime is provided (currently only works with minTime)

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -292,7 +292,7 @@ requires jQuery 1.7+
 
 		list.css({'display':'none', 'position': 'absolute' });
 
-		if (settings.minTime !== null && settings.showDuration) {
+		if ((settings.minTime !== null || settings.durationTime !== null) && settings.showDuration) {
 			list.addClass('ui-timepicker-with-duration');
 		}
 
@@ -311,7 +311,7 @@ requires jQuery 1.7+
 			row.data('time', timeInt);
 			row.text(_int2time(timeInt, settings.timeFormat));
 
-			if (settings.minTime !== null && settings.showDuration) {
+			if ((settings.minTime !== null || settings.durationTime !== null) && settings.showDuration) {
 				var duration = $('<span />');
 				duration.addClass('ui-timepicker-duration');
 				duration.text(' ('+_int2duration(i - durStart)+')');


### PR DESCRIPTION
The documentation states "showDuration Shows the relative time for each item in the dropdown. minTime or durationTime must be set.", but durations were only rendering with a minTime.
