### PR TITLE
Adds support for a zero-based fixed-position parser

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -640,14 +640,24 @@ requires jQuery 1.7+
 		}
 
 		var d = new Date(0);
-		var time = timeString.toLowerCase().match(/(\d{1,2})(?::(\d{1,2}))?(?::(\d{2}))?\s*([pa]?)/);
+
+		var time;
+		if (timeString.indexOf(":") !== -1) {
+			//colon-delimited version
+			console.log('colon-delimited version');
+			time = timeString.toLowerCase().match(/(\d{1,2})(?::(\d{1,2}))?(?::(\d{2}))?\s*([pa]?)/);
+		} else {
+			//zero-required, fixed-position version
+			console.log('fixed-position version');
+			time = timeString.toLowerCase().match(/^([0-2][0-9]):?([0-5][0-9])?:?([0-5][0-9])?\s*([pa]?)$/);
+		}
 
 		if (!time) {
 			return null;
 		}
 
 		var hour = parseInt(time[1]*1, 10);
-        var hours;
+		var hours;
 
 		if (time[4]) {
 			if (hour == 12) {


### PR DESCRIPTION
If any colon is present in the time string, it uses the existing
colon-based parser.  Otherwise, it uses a zero-based, fixed-position
parser.  The zero-based version is useful for users who would like to
use the keypad, possibly for batch-style input.

All time strings end up in a format that contains a colon so the
colon-based parser is always used for presentation to the user.

Examples of acceptable input to the zero-based regex (notice that the colon is still optionally allowed):

"080501".match(/^([0-2][0-9]):?([0-5][0-9])?:?([0-5][0-9])?\s*([pa]?)$/);
["080501", "08", "05", "01", ""]

"080501p".match(/^([0-2][0-9]):?([0-5][0-9])?:?([0-5][0-9])?\s*([pa]?)$/);
["080501p", "08", "05", "01", "p"]

"081511p".match(/^([0-2][0-9]):?([0-5][0-9])?:?([0-5][0-9])?\s*([pa]?)$/);
["081511p", "08", "15", "11", "p"]

"130411a".match(/^([0-2][0-9]):?([0-5][0-9])?:?([0-5][0-9])?\s*([pa]?)$/);
["130411a", "13", "04", "11", "a"]

"13:0411a".match(/^([0-2][0-9]):?([0-5][0-9])?:?([0-5][0-9])?\s*([pa]?)$/);
["13:0411a", "13", "04", "11", "a"]

"13:04:11a".match(/^([0-2][0-9]):?([0-5][0-9])?:?([0-5][0-9])?\s*([pa]?)$/);
["13:04:11a", "13", "04", "11", "a"]
