### PR TITLE
Close picker on scroll.

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -17,7 +17,7 @@ requires jQuery 1.7+
 }(function ($) {
 	var _baseDate = _generateBaseDate();
 	var _ONE_DAY = 86400;
-	var _closeEvent = 'ontouchstart' in document ? 'touchstart' : 'mousedown';
+	var _closeEvent = 'ontouchstart' in document ? 'touchstart' : 'mousedown DOMMouseScroll mousewheel';
 	var _defaults =	{
 		className: null,
 		minTime: null,


### PR DESCRIPTION
The picker doesn't close on scroll with my touchpad in Chrome, so I've extended the list of events to be watched. Apologies for lack of a complete patch, I don't have npm to get grunt and create a minified version.
