### PR TITLE
Fixing offset position

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -131,12 +131,20 @@ requires jQuery 1.7+
 			// make sure other pickers are hidden
 			methods.hide();
 
+			var settings = self.data('timepicker-settings');
+
+			settings.appendTo = $(settings.appendTo);
+			var parentOffset = {
+				top: settings.appendTo.offset().top - settings.appendTo.scrollTop(),
+				left: settings.appendTo.offset().left - settings.appendTo.scrollLeft(),
+			};
+
 			if ((self.offset().top + self.outerHeight(true) + list.outerHeight()) > $(window).height() + $(window).scrollTop()) {
 				// position the dropdown on top
-				list.css({ 'left':(self.offset().left), 'top': self.offset().top - list.outerHeight() });
+				list.css({ 'left':(self.offset().left - parentOffset.left), 'top': self.offset().top - list.outerHeight() - parentOffset.top });
 			} else {
 				// put it under the input
-				list.css({ 'left':(self.offset().left), 'top': self.offset().top + self.outerHeight() });
+				list.css({ 'left':(self.offset().left - parentOffset.left), 'top': self.offset().top + self.outerHeight() - parentOffset.top });
 			}
 
 			list.show();


### PR DESCRIPTION
I'm using `appendTo` because I've got an inner div that scrolls (instead of the entire `body`), which is where the timepicker is.

Without this patch, the timepicker appears in the wrong place.

I'm not sure if this is the perfect patch since I haven't tested other situations, but it fixes my problem - so at least something worth looking into for you...
