### PR TITLE
Time picker not hiding onblur / firing onchange after editing the text directly.

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -433,6 +433,11 @@ requires jQuery 1.7+
 
 		var prettyTime = _int2time(seconds, settings.timeFormat);
 		self.val(prettyTime);
+
+		// if select on blur enabled, ensure we close the selections after any text edit
+        if (settings.selectOnBlur) {
+            methods.hide.apply(this);
+        }
 	}
 
 	function _keyhandler(e)


### PR DESCRIPTION
Hey, first time git commit so hopefully I've done this correctly....

The time picker selection box does not hide / fire an onchange event after editing the text field directly. For an example see this [JSFiddle example](http://jsfiddle.net/doddieaj/p7RsT/), select the input, edit the text and then click somewhere else in the page.

I'm not sure if this is the best place to insert the hide method or whether it should be linked with the selectOnBlur behaviour, but this change fixes the behaviour (in fact I believe it might be best tied to a setting called "updateOnBlur" or something).

NB: This bug exists in Chrome, FF 18 & Opera 12.
NB: Seems related to pull requests 23 & 26.

Thanks
