### PR TITLE
Time picker not firing onchange after editing the text directly.

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -87,6 +87,7 @@ requires jQuery 1.7+
 				self.on('click.timepicker focus.timepicker', methods.show);
 				self.on('blur.timepicker', _formatValue);
 				self.on('keydown.timepicker', _keyhandler);
+				self.on('change', function (){self.trigger('changeTime');});
 				self.addClass('ui-timepicker-input');
 
 				_formatValue.call(self.get(0));
@@ -433,11 +434,6 @@ requires jQuery 1.7+
 
 		var prettyTime = _int2time(seconds, settings.timeFormat);
 		self.val(prettyTime);
-
-		// if select on blur enabled, ensure we close the selections after any text edit
-        if (settings.selectOnBlur) {
-            methods.hide.apply(this);
-        }
 	}
 
 	function _keyhandler(e)


### PR DESCRIPTION
Hey, (first time git commit so hopefully I've done this correctly...., well technically second)

The time picker selection box does not fire an onchange event after editing the text field directly.

This is my second attempt at a fix for this. I'm not sure this is elegant but I register a handler to trigger the changeTime event when the input box gets its own change event.

NB: This bug exists in Chrome, FF 18 & Opera 12.
NB: Seems related to pull requests 23 & 26.

Thanks
