### PR TITLE
Datepair fixes and improvements

### DIFF
--- a/lib/datepair.js
+++ b/lib/datepair.js
@@ -215,7 +215,7 @@ function parseDate(input, format) {
 	// extract date-part indexes from the format
 	format.replace(/(yyyy|dd?|mm?)/g, function(part) { fmt[part] = i++; });
 
-	return new Date(parts[fmt['yyyy']], parts[fmt['mm'] || fmt['m']]-1, parts[fmt['dd'] || fmt['d']]);
+	return new Date(parts[fmt['yyyy']], parts[fmt['mm'] == undefined ? fmt['m'] : fmt['mm']]-1, parts[fmt['dd'] == undefined ? fmt['d'] : fmt['dd']]);
 }
 
 // Simulates PHP's date function


### PR DESCRIPTION
The datepair example isn't working properly.

Setting start and end to the same date, then changing the start date to another date will not update the end date. Also, changing the start time doesn't correctly set the minTime. This commit addresses these issues.

Additionally, javascripts built in Date parse is very limited. I added a basic parsing function so that you can now use date formats like `dd.mm.yyyy`.

Still, the datepair is far from perfect. A proper js date library should be added in the future.
