### PR TITLE
End time duration scroll on focus

### DIFF
--- a/lib/datepair.js
+++ b/lib/datepair.js
@@ -29,6 +29,10 @@ $(function() {
 		if ($this.hasClass('start') || $this.hasClass('end')) {
 			$this.on('changeTime change', doDatepair);
 		}
+		
+		if ($this.hasClass('end')) {
+			$this.on('focus', function(){$('.ui-timepicker-with-duration').scrollTop(0);});
+		}		
 
 	});
 


### PR DESCRIPTION
The end time duration dropdown was not always scrolled to the top onfocus - either by tabbing or by mouse.

This fix ensures that the highlighted end time is visible on focus.

Tested w/ : 
Chrome 26.0.1410.64
Firefox 20.0.1
