### PR TITLE
Positioning bug in IE8 where margin = auto

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -120,7 +120,14 @@ requires jQuery 1.7+
 
 			list.show();
 
-			if ((self.offset().top + self.outerHeight(true) + list.outerHeight()) > $(window).height() + $(window).scrollTop()) {
+			 // Fixes bug in IE8 where margin === 'auto'
+            if (list.css('margin-top') === 'auto') {
+                list.offset({
+                    'left': self.offset().left,
+                    'top': self.offset().top
+                });
+
+            } else if ((self.offset().top + self.outerHeight(true) + list.outerHeight()) > $(window).height() + $(window).scrollTop()) {
 				// position the dropdown on top
 				list.offset({
 					'left': self.offset().left + parseInt(list.css('marginLeft').replace('px', ''), 10),


### PR DESCRIPTION
Relates to issue #117

In Chrome.. list.css('margin-top') === '0px'
However, in IE8... list.css('margin-top') === 'auto'

Then, when the code tries to parse into an integer...
parseInt(list.css('marginLeft').replace('px', ''), 10)

Chrome = 0 
IE8 = NaN

This causes the timepicker to always appear as 0, 0 position in IE8 if margin auto is used.
