### PR TITLE
replaced .datepicker('update'); to .datepicker('refresh');

### DIFF
--- a/lib/datepair.js
+++ b/lib/datepair.js
@@ -7,7 +7,7 @@ $(function() {
 		var $this = $(this);
 
 		$this.datepicker({
-			'format': DATEPICKER_FORMAT,
+			'dateFormat': DATEPICKER_FORMAT,
 			'autoclose': true
 		});
 


### PR DESCRIPTION
Changing value in 'input.date.start' was throwing "Uncaught TypeError: Cannot call method 'css' of undefined" upon calling .datepicker('update').

Looking at datepicker docu, I can't see reference to a 'update' method, but there is 'refresh'. Changing to 'refresh' solves the problem.

http://api.jqueryui.com/datepicker/#method-refresh
