### PR TITLE
Calling $input.timepicker('setTime', dateObj); was not triggering change event

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -702,7 +702,7 @@ requires jQuery 1.7+
 			if (source == 'select') {
 				self.trigger('selectTime').trigger('changeTime').trigger('change');
 			} else if (source != 'error') {
-				self.trigger('changeTime');
+				self.trigger('changeTime').trigger('change');
 			}
 
 			return true;


### PR DESCRIPTION
I.e. I was trying to call `$input.timepicker('setTime', dateObj);` from another plugin directly, and noticed the change event was not firing - thus breaking AngularJS two-way binding
