### PR TITLE
Better duration notation for non-default steps, eg: 1 hr 15 mins

### DIFF
--- a/jquery.timepicker.css
+++ b/jquery.timepicker.css
@@ -13,6 +13,11 @@
 }
 
 .ui-timepicker-wrapper.ui-timepicker-with-duration {
+	width: 14em;
+}
+
+.ui-timepicker-wrapper.ui-timepicker-with-duration.ui-timepicker-step-30,
+.ui-timepicker-wrapper.ui-timepicker-with-duration.ui-timepicker-step-60 {
 	width: 11em;
 }
 

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -391,6 +391,7 @@ requires jQuery 1.7+
 
 		if ((settings.minTime !== null || settings.durationTime !== null) && settings.showDuration) {
 			wrapped_list.addClass('ui-timepicker-with-duration');
+			wrapped_list.addClass('ui-timepicker-step-'+settings.step);
 		}
 
 		var durStart = settings.minTime;
@@ -904,17 +905,31 @@ requires jQuery 1.7+
 
 	function _int2duration(seconds)
 	{
-		var minutes = Math.round(seconds/60);
-		var duration;
+		var minutes = Math.round(seconds/60),
+			duration = [],
+			hours, mins;
 
-		if (Math.abs(minutes) < 60) {
+		if (minutes < 60) {
+			// Only show (x mins) under 1 hour
 			duration = [minutes, _lang.mins];
-		} else if (minutes == 60) {
-			duration = ['1', _lang.hr];
 		} else {
-			var hours = (minutes/60).toFixed(1);
-			if (_lang.decimal != '.') hours = hours.replace('.', _lang.decimal);
-			duration = [hours, _lang.hrs];
+			hours = Math.floor(minutes/60);
+			mins = minutes%60;
+
+			// Show decimal notation (eg: 1.5 hrs) for 30 minute steps
+			if (step == 30 && mins == 30) {
+				hours += _lang.decimal + 5;
+			}
+
+			duration.push(hours);
+			duration.push(hours == 1 ? _lang.hr : _lang.hrs);
+
+			// Show remainder minutes notation (eg: 1 hr 15 mins) for non-30 minute steps
+			// and only if there are remainder minutes to show
+			if (step != 30 && mins) {
+				duration.push(mins);
+				duration.push(_lang.mins);
+			}
 		}
 
 		return duration.join(' ');


### PR DESCRIPTION
I noticed that if the `step` setting was set to anything other than 30 or 60, the notation for the duration of an option could be confusing. For example, a 15 minute interval could result in _(1.8 hrs)_ which makes no real sense.

Now, using a 30 minute step will keep current notation of _(1.5 hrs)_, but setting it to something else will give you something like _(1 hr 45 mins)_.

I've added the class name `.ui-timepicker-step-x` (where x is the `step` value) to make sure the wrapper is wide enough for this longer notation.

![screenshot 2014-05-22 12 05 03](https://cloud.githubusercontent.com/assets/59516/3052282/97243834-e198-11e3-8ca3-fcef8c5c7fbb.png)

Oh, and I haven't minified the JS here just yet.
