### PR TITLE
Add step as argument in _int2duration

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -903,7 +903,7 @@ requires jQuery 1.7+
 		return true;
 	}
 
-	function _int2duration(seconds)
+	function _int2duration(seconds, step)
 	{
 		var minutes = Math.round(seconds/60),
 			duration = [],


### PR DESCRIPTION
Sorry dude, forgot this one. Version 1.3.8 now throws an error when the duration is shown.
