### PR TITLE
Override default behavior on readonly inputs

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -35,7 +35,8 @@ requires jQuery 1.7+
 		disableTimeRanges: [],
 		closeOnWindowScroll: false,
 		typeaheadHighlight: true,
-		noneOption: false
+		noneOption: false,
+		openOnReadOnly: false
 	};
 	var _lang = {
 		am: 'am',
@@ -114,7 +115,7 @@ requires jQuery 1.7+
 			var list = self.data('timepicker-list');
 
 			// check if input is readonly
-			if (self.prop('readonly')) {
+			if (self.prop('readonly') && !settings.openOnReadOnly) {
 				return;
 			}
 


### PR DESCRIPTION
Add a 'openOnReadOnly' option to make readonly input trigering the dropdown when clicked.
Several issues have already been opened about this, it's a quite common use case.
