### PR TITLE
Rename to bower.json and only include one script

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
     "version"      : "1.4.6",
     "description"  : "A jQuery timepicker plugin inspired by Google Calendar.",
     "homepage"     : "http://jonthornton.github.com/jquery-timepicker",
-    "main"         : [ "./jquery.timepicker.js", "./jquery.timepicker.min.js", "./jquery.timepicker.css" ],
+    "main"         : [ "./jquery.timepicker.js", "./jquery.timepicker.css" ],
     "dependencies" : {
         "jquery" : ">= 1.7"
     },


### PR DESCRIPTION
Right now the `component.json` lists the same file twice -- minified and not. Installing via `bower` will include both scripts, which is redundant. Typically the unminified file is listed under `main` and minification is left to the implementer.

Also, the name `component.json` is deprecated and `bower.json` should be used to avoid being unsupported in the future.

Love this by the way. I'm using angular and bootstrap 3 and the other 2 decent solutions aren't nearly as clean.
