### PR TITLE
Add a setting to show the timepicker on readonly inputs

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -94,7 +94,7 @@ requires jQuery 1.7+
 			var list = self.data('timepicker-list');
 
 			// check if input is readonly
-			if (self.prop('readonly')) {
+			if (self.prop('readonly') && !settings.showOnReadonly) {
 				return;
 			}
 
@@ -1110,6 +1110,7 @@ requires jQuery 1.7+
 		step: 30,
 		showDuration: false,
 		showOnFocus: true,
+		showOnReadonly: false,
 		timeFormat: 'g:ia',
 		scrollDefault: null,
 		selectOnBlur: false,


### PR DESCRIPTION
Defaulting to the current behavior of hiding on readonly, but allow the user to flip that switch via a setting.

Use case here is for an input where we don't want the users to be able to edit the text directly, only using the timepicker to choose options, in order to ensure we get the correct data format.
