### PR TITLE
return selected time value to selectTime event callback

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -766,7 +766,7 @@ requires jQuery 1.7+
 
 			return true;
 		} else {
-			self.trigger('selectTime');
+			self.trigger('selectTime', [value]);
 			return false;
 		}
 	}


### PR DESCRIPTION
This takes care of my suggestion: https://github.com/jonthornton/jquery-timepicker/issues/302

Goes good with the "Non-input Example".

Usage:

```
$(".non-input-with-picker").timepicker();
$(".non-input-with-picker").on("click", function() {
    $(this).timepicker("show");
});
$(".non-input-with-picker").on("selectTime", function(event, selectedTime) {
    // do stuff with selectedTime (ex: "1:30pm")
});
```
