### PR TITLE
Handles periods in the AM/PM designator

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -1070,7 +1070,15 @@ requires jQuery 1.7+
 			return timeString.getHours()*3600 + timeString.getMinutes()*60 + timeString.getSeconds();
 		}
 
-		timeString = timeString.toLowerCase();
+		timeString = timeString.toLowerCase().trim();
+
+		// if the AM/PM designator contains periods then remove them
+		if (timeString.slice(-1) == '.') {
+			timeString = timeString.substring(0, timeString.length - 1);
+		}
+		if (timeString.slice(-2) == '.m') {
+			timeString = timeString.substring(0, timeString.length - 2) + "m";
+		}
 
 		// if the last character is an "a" or "p", add the "m"
 		if (timeString.slice(-1) == 'a' || timeString.slice(-1) == 'p') {


### PR DESCRIPTION
I noticed that as soon as users entered a period in the AM/PM designator (p.m., pm., etc.) that parsing would fail. I added code to remove periods if they're in the time string. I've never created a pull request so please don't hesitate to let me know if I'm doing something wrong. Thanks for the great time picker!