### PR TITLE
Fix escaping character in time format

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -1038,7 +1038,7 @@
 				case '\\':
 					// escape character; add the next character and skip ahead
 					i++;
-					output += format.charAt(i);
+					output += settings.timeFormat.charAt(i);
 					break;
 
 				default:


### PR DESCRIPTION
We've (co-workers) found an issue with the time format.