### PR TITLE
typeaheadHighlight fixes

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -867,7 +867,7 @@
 			return true;
 		}
 
-        // Don't hide the selected row if they pressed up/down
+		// Don't hide the selected row if they pressed up/down
 		if (!self.data('timepicker-settings').typeaheadHighlight && e.keyCode !== 38 && e.keyCode !== 40) {
 			list.find('li').removeClass('ui-timepicker-selected');
 			return true;

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -865,7 +865,8 @@
 			return true;
 		}
 
-		if (!self.data('timepicker-settings').typeaheadHighlight) {
+        // Don't hide the selected row if they pressed up/down
+		if (!self.data('timepicker-settings').typeaheadHighlight && e.keyCode !== 38 && e.keyCode !== 40) {
 			list.find('li').removeClass('ui-timepicker-selected');
 			return true;
 		}

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -683,7 +683,7 @@
 
 		var self = $(this);
 
-		if (self.is(':focus') && (!e || e.type != 'change')) {
+		if (self.is(':focus') && (!e || (e.type !== 'change' && !(e.type === 'keydown' && e.keyCode === 13)))) {
 			return;
 		}
 
@@ -787,6 +787,8 @@
 
 			case 13: // return
 				if (_selectValue(self)) {
+					// Format the entered value before hiding
+					_formatValue.call(self.get(0), e);
 					methods.hide.apply(this);
 				}
 


### PR DESCRIPTION
After your response to #365, I enabled typeaheadHighlight and it mostly worked as expected but there were a few small issues that I wanted to take care of.

- Having `typeaheadHighlight` enabled was preventing rows from being selected with the up/down arrow keys. 56a2e8d fixes this.

- While the dropdown is displayed, and the user types a time that needs to be formatted (e.g. "120p") and then hits ENTER, the dropdown would disappear but the time wouldn't be formatted. Commit 81ae8d5 fixes this.

- And then I realized that I used spaces instead of tabs... 5f27e51 fixes that :)