### PR TITLE
feat: add option to prevent scroll propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Display a timepicker dropdown when the input gains focus.
 The amount of time, in minutes, between each item in the dropdown. Alternately, you can specify a function to generate steps dynamically. The function will receive a count integer (0, 1, 2...) and is expected to return a step integer.  
 *default: 30*
 
+- **stopScrollPropagation**
+When scrolling on the edge of the picker, it prevent parent containers (<body>) to scroll.
+
 - **timeFormat**  
 How times should be displayed in the list and input element. Uses [PHP's date() formatting syntax](http://php.net/manual/en/function.date.php). Characters can be escaped with a preceeding double slash (e.g. `H\\hi`). Alternatively, you can specify a function instead of a string, to use completely custom time formatting. In this case, the format function receives a Date object and is expected to return a string.
 *default: 'g:ia'*

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -172,6 +172,15 @@
 				list.scrollTop(0);
 			}
 
+			// prevent scroll propagation
+			if(settings.stopScrollPropagation) {
+				$(document).on('wheel.ui-timepicker', '.ui-timepicker-wrapper', function(e){
+					e.preventDefault();
+					var currentScroll = $(this).scrollTop();
+					$(this).scrollTop(currentScroll + e.originalEvent.deltaY);
+				});
+			}
+
 			// attach close handlers
 			$(document).on('touchstart.ui-timepicker mousedown.ui-timepicker', _closeHandler);
 			$(window).on('resize.ui-timepicker', _closeHandler);
@@ -1175,6 +1184,7 @@
 		closeOnWindowScroll: false,
 		typeaheadHighlight: true,
 		noneOption: false,
-		show2400: false
+		show2400: false,
+		stopScrollPropagation: false
 	};
 }));


### PR DESCRIPTION
Hi @jonthornton,
I tried to fix the scroll event being propagated as discussed [here](https://github.com/jonthornton/jquery-timepicker/pull/97). The issue is old, but I think it's still not fixed, is it ?

Here is a [demo plunkr](http://plnkr.co/edit/lSNXwZGjuMcigPT2Uiun?p=preview)
I sticked to the [WheelEvent spec](http://www.w3.org/TR/DOM-Level-3-Events/#events-wheelevents).
The event listener should be cleared by `_closeHandler` function, thanks to the `ui-timepicker` namespace.