### PR TITLE
Setting relative date to today causes issues when today is a day that…

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Get the time as an integer, expressed as seconds from 12am.
 	```
 
 - **getTime**  
-Get the time using a Javascript Date object, relative to a Date object (default: today).
+Get the time using a Javascript Date object, relative to a Date object (default: Jan 1, 1970).
 
 	```javascript
 	$('#getTimeExample').timepicker('getTime');

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -275,10 +275,10 @@
 			}
 
 			if (!relative_date) {
-				relative_date = new Date();
+				relative_date = _baseDate;
 			}
 
-			// construct a Date with today's date, and offset's time
+			// construct a Date from relative date, and offset's time
 			var time = new Date(relative_date);
 			time.setHours(offset / 3600);
 			time.setMinutes(offset % 3600 / 60);


### PR DESCRIPTION
… DST is dropped or added.

The issue is that in getTime: we set relative_date to today (if none is provided). If today happens to be a day in which DST is either dropped or started timezones can be changed by Javascript's Date class resulting in odd behavior such as when paired with Datepair.

For example:

1. Set your Computer's date to Nov 1, 2015
2. Vist: http://jsfiddle.net/kylethielk/oo29mj69/2/
3. Click the Initialize Time button.
4. Click the "Get Time" button.
5. Notice that the timezone is different in what your browser has, versus what getTime returns


![screen shot 2015-11-01 at 3 37 05 pm](https://cloud.githubusercontent.com/assets/3186142/10895037/9c13fd2c-8177-11e5-998e-e1d59c79a7d9.png)


 