### PR TITLE
handle situation where timeString is initialized with null

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -1085,7 +1085,7 @@
 
 	function _time2int(timeString, settings)
 	{
-		if (timeString === '') return null;
+		if (timeString === '' || timeString === null) return null;
 		if (typeof timeString == 'object') {
 			return timeString.getHours()*3600 + timeString.getMinutes()*60 + timeString.getSeconds();
 		}


### PR DESCRIPTION
Was having a problem with this, when initializing the time with a null value.  The problem is that `typeof null === 'object', so it tries to call `getHours()` on the null object.