### PR TITLE
Fix range error when outside min/max time

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -734,8 +734,8 @@
 
 		var rangeError = false;
 		// check that the time in within bounds
-		if (settings.minTime !== null && seconds < settings.minTime
-			&& settings.maxTime !== null && seconds > settings.maxTime) {
+		if ((settings.minTime !== null && seconds < settings.minTime)
+			|| (settings.maxTime !== null && seconds > settings.maxTime)) {
 			rangeError = true;
 		}
 


### PR DESCRIPTION
The previous implementation of range error on min/max time involved seconds < settings.minTime && seconds > settings.maxTime which would never be true.  Implementing as an or condition so that either before or after will trigger a range error.