### PR TITLE
Fix forceRoundTime with minTime glitch

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -1214,6 +1214,10 @@
 				return seconds;
 			} else {
 				var offset = seconds % (settings.step*60); // step is in minutes
+				
+				var start = (settings.minTime !== null) ? settings.minTime : 0;
+                		// adjust offset by start mod step so that the offset is aligned not to 00:00 but to the start
+                		offset -= start % (settings.step * 60);
 
 				if (offset >= settings.step*30) {
 					// if offset is larger than a half step, round up


### PR DESCRIPTION
If forceRoundTime is true, and a step is given, and minTime is set, an inconsistency can occur when minTime is not a multiple of step from midnight.  For example, consider the case of a minTime of 6:45am and a step of 6. The documentation says "Setting forceRoundTime to true will round the entered time to the nearest option on the dropdown list."  However, in the case given, the dropdown will have 6:45am, 6:51am, 6:57am, ... but the initial value will set to 6:48am and if I type in, say, 6:51am it will jump to 6:54am which isn't even one of the dropdown options.
