### PR TITLE
Intelligently scroll to first selectable time

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -217,6 +217,11 @@
 				}
 			}
 
+			// if not found or disabled, intelligently find first selectable element
+			if (!selected.length || selected.hasClass('ui-timepicker-disabled')) {
+				selected = list.find('li:not(.ui-timepicker-disabled):first');
+			}
+			
 			if (selected && selected.length) {
 				var topOffset = list.scrollTop() + selected.position().top - selected.outerHeight();
 				list.scrollTop(topOffset);


### PR DESCRIPTION
When disabling a range of times from 12am, the dropdown show the not selectable range of times.
To improve user experience, the timepicker could automatically scroll to the first selectable time.

**Example 1:**
```JS
$(...).timepicker({
    disableTimeRanges: [['00:00', '11:00']]
});
```
![1](https://cloud.githubusercontent.com/assets/25922153/23212035/1d478db8-f905-11e6-9b9f-4e835272932a.PNG)

**Example 2:**
Default scroll is set to 7am, but first selectable time is 11am.
```JS
$(...).timepicker({
    disableTimeRanges: [['00:00', '11:00']],
    scrollDefault: '07:00'
});
```
![2](https://cloud.githubusercontent.com/assets/25922153/23212482/3067abba-f907-11e6-9434-3dee615d4fea.PNG)


**Expected in both cases:**
![1-expected](https://cloud.githubusercontent.com/assets/25922153/23212064/401a600e-f905-11e6-81e7-1f5501be83f1.PNG)

