### PR TITLE
Fix dropdown position when resizing window or scrolling parent block

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -170,40 +170,11 @@
 			// make sure other pickers are hidden
 			methods.hide();
 
-			// position the dropdown relative to the input
 			list.show();
 			var listOffset = {};
-
-			if (settings.orientation.match(/r/)) {
-				// right-align the dropdown
-				listOffset.left = self.offset().left + self.outerWidth() - list.outerWidth() + parseInt(list.css('marginLeft').replace('px', ''), 10);
-			} else {
-				// left-align the dropdown
-				listOffset.left = self.offset().left + parseInt(list.css('marginLeft').replace('px', ''), 10);
-			}
-
-			var verticalOrientation;
-			if (settings.orientation.match(/t/)) {
-				verticalOrientation = 't';
-			} else if (settings.orientation.match(/b/)) {
-				verticalOrientation = 'b';
-			} else if ((self.offset().top + self.outerHeight(true) + list.outerHeight()) > $(window).height() + $(window).scrollTop()) {
-				verticalOrientation = 't';
-			} else {
-				verticalOrientation = 'b';
-			}
-
-			if (verticalOrientation == 't') {
-				// position the dropdown on top
-				list.addClass('ui-timepicker-positioned-top');
-				listOffset.top = self.offset().top - list.outerHeight() + parseInt(list.css('marginTop').replace('px', ''), 10);
-			} else {
-				// put it under the input
-				list.removeClass('ui-timepicker-positioned-top');
-				listOffset.top = self.offset().top + self.outerHeight() + parseInt(list.css('marginTop').replace('px', ''), 10);
-			}
-
-			list.offset(listOffset);
+			
+			// position the dropdown relative to the input
+            		_updatePosition();
 
 			// position scrolling
 			var selected = list.find('.ui-timepicker-selected');
@@ -236,9 +207,10 @@
 			// attach close handlers
 			$(document).on('touchstart.ui-timepicker mousedown.ui-timepicker', _closeHandler);
 			$(window).on('resize.ui-timepicker', _closeHandler);
-			if (settings.closeOnWindowScroll) {
-				$(document).on('scroll.ui-timepicker', _closeHandler);
-			}
+			$(document).on(
+				'scroll.ui-timepicker',
+				settings.closeOnWindowScroll ? _closeHandler : _updatePosition
+			);
 
 			self.trigger('showTimepicker');
 
@@ -1239,6 +1211,55 @@
 
 		return seconds%_ONE_DAY;
 	}
+	
+	function _updatePosition(e) {
+		$('.ui-timepicker-wrapper').each(function () {
+			var list = $(this);
+			if (!_isVisible(list)) {
+				return;
+			}
+			
+			var self = list.data('timepicker-input');
+			var settings = self.data('timepicker-settings');
+			
+			if (settings.useSelect) {
+				return;
+			}
+			
+			var listOffset = {};
+
+			if (settings.orientation.match(/r/)) {
+				// right-align the dropdown
+				listOffset.left = self.offset().left + self.outerWidth() - list.outerWidth() + parseInt(list.css('marginLeft').replace('px', ''), 10);
+			} else {
+				// left-align the dropdown
+				listOffset.left = self.offset().left + parseInt(list.css('marginLeft').replace('px', ''), 10);
+			}
+
+			var verticalOrientation;
+			if (settings.orientation.match(/t/)) {
+				verticalOrientation = 't';
+			} else if (settings.orientation.match(/b/)) {
+				verticalOrientation = 'b';
+			} else if ((self.offset().top + self.outerHeight(true) + list.outerHeight()) > $(window).height() + $(window).scrollTop()) {
+				verticalOrientation = 't';
+			} else {
+				verticalOrientation = 'b';
+			}
+
+			if (verticalOrientation == 't') {
+				// position the dropdown on top
+				list.addClass('ui-timepicker-positioned-top');
+				listOffset.top = self.offset().top - list.outerHeight() + parseInt(list.css('marginTop').replace('px', ''), 10);
+			} else {
+				// put it under the input
+				list.removeClass('ui-timepicker-positioned-top');
+				listOffset.top = self.offset().top + self.outerHeight() + parseInt(list.css('marginTop').replace('px', ''), 10);
+			}
+
+			list.offset(listOffset);
+		});
+    	}
 
 	// Plugin entry
 	$.fn.timepicker = function(method)
@@ -1254,4 +1275,6 @@
 		else if(typeof method === "object" || !method) { return methods.init.apply(this, arguments); }
 		else { $.error("Method "+ method + " does not exist on jQuery.timepicker"); }
 	};
+	
+	$.fn.timepicker.updatePosition = _updatePosition;
 }));

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -34,6 +34,7 @@
 		appendTo: 'body',
 		className: null,
 		closeOnWindowScroll: false,
+        	closeOnWindowResize: false,
 		disableTextInput: false,
 		disableTimeRanges: [],
 		disableTouchKeyboard: false,
@@ -206,7 +207,10 @@
 
 			// attach close handlers
 			$(document).on('touchstart.ui-timepicker mousedown.ui-timepicker', _closeHandler);
-			$(window).on('resize.ui-timepicker', _closeHandler);
+			$(window).on(
+				'resize.ui-timepicker',
+				settings.closeOnWindowResize ? _closeHandler : _updatePosition
+			);
 			$(document).on(
 				'scroll.ui-timepicker',
 				settings.closeOnWindowScroll ? _closeHandler : _updatePosition


### PR DESCRIPTION
When resizing window or scrolling, the dropdown position is not updated:

**Resize:**
![1](https://cloud.githubusercontent.com/assets/25922153/23214585/85a99216-f90f-11e6-9f28-5685997cfe8a.PNG)
Expected: the dropdown position should be updated according to the new setting option `closeOnWindowResize` value.

**Scroll:**
![2](https://cloud.githubusercontent.com/assets/25922153/23214632/b709f7ce-f90f-11e6-820c-7c2fe6b060a7.PNG)
Expected: add a possibility to refresh the dropdown position when needed according to the `closeOnWindowScroll` setting option value.

The code:
```JS
    $.fn.timepicker.updatePosition = _updatePosition;
```
could be used as below:
```JS
// element is scrollable and contains timepicker fields
$('element').on('scroll.ui-timepicker', $.fn.timepicker.updatePosition);
```
