### PR TITLE
Adapt dropdown width according to rows size

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -205,6 +205,11 @@
 
 			list.offset(listOffset);
 
+			list.width('auto');
+			if (!$.browser.msie || $.browser.version != 9) {
+				list.width(list.innerWidth() + 20);
+			}
+			
 			// position scrolling
 			var selected = list.find('.ui-timepicker-selected');
 


### PR DESCRIPTION
When using time formating, selectable times in dropdown are not readable:

**Example:**
```JS
$(...).timepicker({
    timeFormat: "H:i:s"
});
```
![1](https://cloud.githubusercontent.com/assets/25922153/23215838/19478434-f914-11e6-80c7-393cfbcf378a.PNG)

**Expected:**
![1-expected](https://cloud.githubusercontent.com/assets/25922153/23215915/5ab03f6a-f914-11e6-83b3-673210bba6ef.PNG)

