### PR TITLE
setTime allows to set not allowed time

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -362,7 +362,9 @@
 				prettyTime = value;
 			}
 
-			_setTimeValue(self, prettyTime);
+			self.val(prettyTime);
+			_formatValue.call(self.get(0), {'type':'change'});
+
 			if (self.data('timepicker-list')) {
 				_setSelected(self, self.data('timepicker-list'));
 			}


### PR DESCRIPTION
**Example:**
```JS
$('#example1').timepicker({
    disableTimeRanges: [['0am', '2am']]
});
$('#example2').timepicker({
    minTime: '2am'
});

$('#example1, #example2')
    .on('timeRangeError', function () {
        console.log('timeRangeError!');
    })
    .on('changeTime', function () {
        console.log('changeTime!');
    });
```

We cannot select times before 2am from the dropdown.

However, calling `setTime()` method with an out of range time change the field value and trigger `changeTime` instead of `timeRangeError`:
```JS
$('#example1').timepicker('setTime', '1am');
// ouput: changeTime!

$('#example2').timepicker('setTime', '1am');
// ouput: changeTime!
```

This pull request attempt to solve the problem.