### PR TITLE
Cleaning timepicker input does not trigger changeTime

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -768,11 +768,16 @@
 
 	function _formatValue(e, origin)
 	{
-		if (this.value === '' || origin == 'timepicker') {
+		if (origin == 'timepicker') {
 			return;
 		}
 
 		var self = $(this);
+
+		if (this.value === '') {
+			_setTimeValue(self, null, origin);
+			return;
+		}
 
 		if (self.is(':focus') && (!e || e.type != 'change')) {
 			return;


### PR DESCRIPTION
Consider the following example:
```JS
$('#example')
    .val('07:00')
    .timepicker({
        disableTimeRanges: [['0am', '2am']]
    });
    .on('changeTime', function () {
        console.log('changeTime!');
    });
```

When typing value from keyboard or selecting in dropdown, `changeTime` is triggered.

However, when cleaning value : 
- by using backspaces from keyboard
- Ctrl-X
- by calling `$('#example').timepicker('setTime', '');`

Input field value is changed but `changeTime` is not triggered.

This pull request attempt to solve the problem.
Waiting for validation :)

