### PR TITLE
Fix JS TypeError when input is readonly

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -891,6 +891,10 @@
 		var self = $(this);
 		var list = self.data('timepicker-list');
 
+		if (self.prop('readonly')) {
+		    return true;
+		}
+		
 		if (!list || !_isVisible(list)) {
 			if (e.keyCode == 40) {
 				// show the list!


### PR DESCRIPTION
If input is readonly, pressing down key (keyCode = 40)  causes a JS TypeError: list is undefined. 
This pull request attempts to fix it in _keydownhandler method.

What do you think? _keyuphandler method does not cause error, but this code should be applied in this method.
