### PR TITLE
Fix cut and paste does not (un)select dropdown time

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -122,6 +122,8 @@
 					if (settings.disableTextInput) {
 						self.on('keydown.timepicker', _disableTextInputHandler);
 					}
+                    			self.on('cut.timepicker', _keyuphandler);
+                    			self.on('paste.timepicker', _keyuphandler);
 
 					_formatValue.call(self.get(0), null, 'initial');
 				}
@@ -986,6 +988,17 @@
 
 		if (!list || !_isVisible(list) || settings.disableTextInput) {
 			return true;
+		}
+		
+		if (e.type === 'paste' || e.type === 'cut') {
+		    	setTimeout(function () {
+				if (settings.typeaheadHighlight) {
+			    		_setSelected(self, list);
+				} else {
+			    		list.hide();
+				}
+		    	}, 0);
+		    	return;
 		}
 
 		switch (e.keyCode) {


### PR DESCRIPTION
When using Ctrl-x shortcut key, the current dropdown value is not unselected.
And when using Ctrl-v, the value is not selected.

![cut](https://cloud.githubusercontent.com/assets/25922153/24464034/ed34ac86-14a8-11e7-8186-83e0b17b9537.PNG)          ![paste](https://cloud.githubusercontent.com/assets/25922153/24464038/f1ab7484-14a8-11e7-9914-88fdce1efe95.PNG)

When initializing timepicker with auto-selection on blur (`$('#example').timepicker({selectOnBlur: true});`), Ctrl-x has no effect: the input is filled with `16:00`.

With this pull-request, timepicker now manage cut/paste events.