### PR TITLE
Fix that selectOnBlur force time rounding with forceRoundTime  = false

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -754,7 +754,8 @@
 	{
 		list.find('li').removeClass('ui-timepicker-selected');
 
-		var timeValue = _time2int(_getTimeValue(self), self.data('timepicker-settings'));
+		var settings = self.data('timepicker-settings');
+		var timeValue = _time2int(_getTimeValue(self), settings);
 		if (timeValue === null) {
 			return;
 		}
@@ -767,8 +768,10 @@
 			if (topDelta + selected.outerHeight() > list.outerHeight() || topDelta < 0) {
 				list.scrollTop(list.scrollTop() + selected.position().top - selected.outerHeight());
 			}
-
-			selected.addClass('ui-timepicker-selected');
+			
+			if (settings.forceRoundTime || selected.data('time') === timeValue) {
+				selected.addClass('ui-timepicker-selected');
+			}
 		}
 	}
 


### PR DESCRIPTION
Considering the code `$('#example').timepicker({selectOnBlur: true});`  
Note that `forceRoundTime` setting is set to `false` by default.

Entering 10:08am highlight 10:00am: ![rounding-0](https://cloud.githubusercontent.com/assets/25922153/24494056/3617c46e-1531-11e7-876b-8ffc2508da33.PNG)  and leaving input apply rounded time: ![rounding-1](https://cloud.githubusercontent.com/assets/25922153/24494062/3d9ebc10-1531-11e7-9f20-d9526c736c2c.PNG).  
The time should not be rounded.

The only way to have the expected behavior is to enter 10:08am, **press escape** to hide the dropdown : ![rounding-escape-0](https://cloud.githubusercontent.com/assets/25922153/24494069/42cacf44-1531-11e7-9aaf-9b76136a8a14.PNG) and to leave the field : ![rounding-escape-1](https://cloud.githubusercontent.com/assets/25922153/24494078/49bc875c-1531-11e7-9b0d-fd369fd690c7.PNG)  

This pull request fix it with a small change in the behavior:
- **changed**: with `forceRoundTime: false`, entering a time that doesn't match with a time in the dropdown **does not highlight** the nearly time. So leaving the field does not apply the auto-selected time. 
- not changed: with `forceRoundTime: true`, entering a time that is not in the dropdown highlight the nearly time.


