### PR TITLE
Fix wrapHours mismatches

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -1203,6 +1203,7 @@
 			return null;
 		}
 
+		var hour = parseInt(time[2]*1, 10);
 		var ampm = time[1] || time[5];
 		var hours = hour;
 		var minutes = ( time[3]*1 || 0 );

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -1203,18 +1203,11 @@
 			return null;
 		}
 
-		var hour = parseInt(time[2]*1, 10);
-		if (hour > 24) {
-			if (settings && settings.wrapHours === false) {
-				return null;
-			} else {
-				hour = hour % 24;
-			}
-		}
-
 		var ampm = time[1] || time[5];
 		var hours = hour;
-
+		var minutes = ( time[3]*1 || 0 );
+		var seconds = ( time[4]*1 || 0 );
+		
 		if (hour <= 12 && ampm) {
 			var isPm = (ampm == _lang.pm || ampm == _lang.PM);
 
@@ -1223,10 +1216,17 @@
 			} else {
 				hours = (hour + (isPm ? 12 : 0));
 			}
+		} else if (settings) {
+			var t = hour * 3600 + minutes * 60 + seconds;
+			if (t >= _ONE_DAY + (settings.show2400 ? 1 : 0)) {
+				if (settings.wrapHours === false) {
+					return null;
+				}
+
+				hours = hour % 24;
+			}
 		}
 
-		var minutes = ( time[3]*1 || 0 );
-		var seconds = ( time[4]*1 || 0 );
 		var timeInt = hours*3600 + minutes*60 + seconds;
 
 		// if no am/pm provided, intelligently guess based on the scrollDefault


### PR DESCRIPTION
This PR fix 2 potential bugs related to the `wrapHours`.  

### Case 1
When initializing timepicker as below:
```
$('#example').timepicker({wrapHours: true});
```
We expect that entering times greater than 24h must select wrapped time.  
For example, entering `25:00` to select `01:00` am):
![wrap-2500](https://cloud.githubusercontent.com/assets/25922153/24713446/fa6bde60-1a25-11e7-931a-eeacf942cc97.PNG)  

But when entering times between `24:00:00` and `24:59:59`, timepicker **does not apply row selection**:
![wrap-2415](https://cloud.githubusercontent.com/assets/25922153/24713488/1eef6716-1a26-11e7-8ca9-5778e4cd1260.PNG)
Fortunately, validating the value apply the wrapped time `00:15`.

**Expected: `00:15` row must be highlighted** 

### Case 2
When initializing timepicker as below:
```
$('#example').timepicker({wrapHours: false});
```
We expect that entering times greater than 24h must not apply the wrapped value and trigger the `timeFormatError` event.
For example, entering `25:00` to select `01:00` am):
![no-wrap-2500](https://cloud.githubusercontent.com/assets/25922153/24714104/d3ffee2c-1a27-11e7-8f19-36ca1a3ade00.PNG)
But when entering times between `24:00:00` and `24:59:59`, timepicker **wrap the value and the unexpected value `00:15` is applied** to the field:
![wrap-2415](https://cloud.githubusercontent.com/assets/25922153/24714240/3b9a49d8-1a28-11e7-857f-982f0544cc11.PNG)

**Expected: entering `24:15` must not select/apply the wrapped value**



