### PR TITLE
Fixed markdown error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Close the timepicker when the window is scrolled. (Replicates ```<select>``` beh
 *default: false*
 
 - **disableTimeRanges**  
-Disable selection of certain time ranges. Input is an array of time pairs, like ```[['3:00am', '4:30am'], ['5:00pm', '8:00pm']]``. The start of the interval will be disabled but the end won't.
+Disable selection of certain time ranges. Input is an array of time pairs, like ```[['3:00am', '4:30am'], ['5:00pm', '8:00pm']]```. The start of the interval will be disabled but the end won't.
 *default: []*
 
 - **disableTextInput**  


### PR DESCRIPTION
showing the disabled dates was not rendering in the appropriate code tags due to a missing ' ` ' at the end.