### PR TITLE
Fix TypeScript error when using "noImplicitAny" compiler option

### DIFF
--- a/jquery.timepicker.d.ts
+++ b/jquery.timepicker.d.ts
@@ -15,7 +15,7 @@ declare namespace Jt.Timepicker {
          * Override where the dropdown is appended.
          * Takes either a string to use as a selector, a function that gets passed the clicked input element as argument or a jquery object to use directly.
          */
-        appendTo?: string | ((clickedElement) => string);
+        appendTo?: string | ((clickedElement: Element) => string);
         /**
          * Default: null
          * A class name to apply to the HTML element that contains the timepicker dropdown.

--- a/jquery.timepicker.d.ts
+++ b/jquery.timepicker.d.ts
@@ -15,7 +15,7 @@ declare namespace Jt.Timepicker {
          * Override where the dropdown is appended.
          * Takes either a string to use as a selector, a function that gets passed the clicked input element as argument or a jquery object to use directly.
          */
-        appendTo?: string | ((clickedElement: Element) => string);
+        appendTo?: string | ((clickedElement: JQuery) => string);
         /**
          * Default: null
          * A class name to apply to the HTML element that contains the timepicker dropdown.


### PR DESCRIPTION
When using the `noImplicitAny` compiler option in TypeScript the missing type definition for the `clickedElement` parameter in the `appendTo` option causes a type error. I assume, that the type of `clickedElement` is `Element` but am not sure. Even explicitly using the any type would resolve the problem and just leave the parameter untyped.