### PR TITLE
Creating a new parameter for object width inheritance

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -177,6 +177,12 @@
       // make sure other pickers are hidden
       methods.hide();
 
+      // set list width to parent element width
+      if(settings.setParentWidth) {
+        if(self.css('width') != 0)
+          list.css('width', self.css('width'));
+      }
+
       // position the dropdown relative to the input
       list.show();
       var listOffset = {};


### PR DESCRIPTION
I created a simple parameter to pull the width from the parent element (element where the click event shows the list of times are set) and apply the width to the element of list of times, with the objetivo to maintain the alignment.

The parameter name is setParentWidth, and should be passed to the library with boolean value.

![jquery-timepicker-example-code](https://user-images.githubusercontent.com/26572725/66509347-3a4ce000-eaa9-11e9-8276-d6520f40db58.png)
