### PR TITLE
Update jquery.timepicker.js

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -433,7 +433,7 @@
       define(["jquery"], factory);
     } else {
       // Browser globals
-      factory(jQuery);
+      factory($);
     }
   })(function ($) {
     var _lang = {};
@@ -1561,7 +1561,7 @@
             seconds -= offset;
           }
 
-          return _moduloSeconds(seconds, settings);
+          return _moduloSeconds$1(seconds, settings);
         }
       },
       scrollDefault: null,


### PR DESCRIPTION
Fix these compile issues:

./src/utils/jquery-timepicker.js
  Line 446:   'jQuery' is not defined          no-undef
  Line 1574:  '_moduloSeconds' is not defined  no-undef