### PR TITLE
Fixes issue where selecting 12:00am would present as 0

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -377,11 +377,7 @@
         var timeValue = cursor.get(0).dataset.time; // selected value found
 
         if (timeValue) {
-          var parsedTimeValue = Number.parseInt(timeValue);
-
-          if (parsedTimeValue) {
-            timeValue = parsedTimeValue;
-          }
+          timeValue = Number.parseInt(timeValue);
         }
 
         if (timeValue !== null) {


### PR DESCRIPTION
Was running into the issue where 12:00am was presenting as 0 on the latest release.

I think the cause of this is when timeValue is "0" parsedTimeValue becomes 0 which is falsey. This means that timeValue never gets updated to 0 and never hits the bit of logic that converts the integer to the time.

As a result "0" appears in the input box instead of the time.

I might of overlooked something here so please feel free to correct me!